### PR TITLE
Fix calculation of wind lever arm

### DIFF
--- a/rust/src/stability/complete.rs
+++ b/rust/src/stability/complete.rs
@@ -39,7 +39,7 @@ pub struct WindHeelingData {
 impl WindHeelingData {
     /// Create new wind heeling data.
     pub fn new(emerged_area: f64, emerged_centroid: [f64; 2], waterline_z: f64) -> Self {
-        let wind_lever_arm = emerged_centroid[1] - waterline_z;
+        let wind_lever_arm = emerged_centroid[1] - 0.5 * waterline_z;
         Self {
             emerged_area,
             emerged_centroid,


### PR DESCRIPTION
According to item 2.3.2 (weather criterion) of the [International Code on Intact Stability (2008)](https://wwwcdn.imo.org/localresources/en/KnowledgeCentre/IndexofIMOResolutions/MSCResolutions/MSC.267(85).pdf):

Z = vertical distance from the centre of A to the centre of the underwater lateral area or approximately to a point at one half the mean draught (m).

Might be a good idea to find a way of introducing the centroid of the submerged lateral area. For now, this quick fix avoids underestimating the values of $l_{w1}$ and $l_{w2}$ in the `rhai` scripts.